### PR TITLE
Add SNAP v13 conda package information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 
 ## Highlights
 
+- SNAP v13 ported into a conda package no needing additional installations.
 - SNAP GPT integration with configurable graphs and operator chaining.
 - WorldSAR preprocessing, tiling, validation, and H5-to-Zarr conversion.
 - Generic pipeline CLI with built-in recipes for Sentinel-1, TSX, CSG, Biomass, NISAR, and Sentinel-1 InSAR.


### PR DESCRIPTION
Updated README to reflect SNAP v13 conda package availability.